### PR TITLE
Environment Variable Standardization for Configuration Path using `CONNECTOR_CONTEXT_PATH` 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ COPY --from=builder /app/target/release/ndc-calcite-cli /usr/local/bin
 COPY --from=java-build /calcite-rs-jni/jni/target/ /calcite-rs-jni/jni/target/
 
 ENV HASURA_CONFIGURATION_DIRECTORY=/etc/connector
+ENV CONNECTOR_CONTEXT_PATH=/etc/connector
 ENV RUST_BACKTRACE=full
 
 WORKDIR /app

--- a/adapters/databricks/configuration.json
+++ b/adapters/databricks/configuration.json
@@ -1,45 +1,23 @@
 {
   "version": "5",
   "$schema": "schema.json",
-  "model": {
-    "version": "1.0",
-    "defaultSchema": "TEST",
-    "schemas": [
-      {
-        "type": "jdbc",
-        "name": "TEST",
-        "sqlDialectFactory": null,
-        "jdbcUser": null,
-        "jdbcPassword": null,
-        "jdbcUrl": "jdbc:databricks://dbc-35019fa9-14d3.cloud.databricks.com:443/;HttpPath=/sql/1.0/warehouses/fd7249aff7e8684c;PWD=dapice663dc29531c32040053109eabdd24f;ConnCatalog=samples;ConnSchema=tpch",
-        "jdbcCatalog": "samples",
-        "jdbcSchema": "tpch",
-        "factory": null
-      }
-    ]
-  },
   "model_file_path": "./model.json",
   "fixes": true,
   "metadata": {
-    "region": {
-      "physicalCatalog": "samples",
-      "physicalSchema": "tpch",
+    "playlisttrack": {
+      "physicalCatalog": "hasura",
+      "physicalSchema": "testing",
       "catalog": "",
       "schema": "TEST",
-      "name": "region",
+      "name": "playlisttrack",
       "columns": {
-        "r_name": {
-          "name": "r_name",
-          "scalarType": "VARCHAR",
+        "PlaylistId": {
+          "name": "PlaylistId",
+          "scalarType": "INTEGER",
           "nullable": true
         },
-        "r_comment": {
-          "name": "r_comment",
-          "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "r_regionkey": {
-          "name": "r_regionkey",
+        "TrackId": {
+          "name": "TrackId",
           "scalarType": "INTEGER",
           "nullable": true
         }
@@ -47,178 +25,181 @@
       "primaryKeys": [],
       "exportedKeys": []
     },
-    "lineitem": {
-      "physicalCatalog": "samples",
-      "physicalSchema": "tpch",
+    "playlist": {
+      "physicalCatalog": "hasura",
+      "physicalSchema": "testing",
       "catalog": "",
       "schema": "TEST",
-      "name": "lineitem",
+      "name": "playlist",
       "columns": {
-        "l_orderkey": {
-          "name": "l_orderkey",
+        "Name": {
+          "name": "Name",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "PlaylistId": {
+          "name": "PlaylistId",
           "scalarType": "INTEGER",
-          "nullable": true
-        },
-        "l_tax": {
-          "name": "l_tax",
-          "scalarType": "FLOAT",
-          "nullable": true
-        },
-        "l_linestatus": {
-          "name": "l_linestatus",
-          "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "l_suppkey": {
-          "name": "l_suppkey",
-          "scalarType": "INTEGER",
-          "nullable": true
-        },
-        "l_extendedprice": {
-          "name": "l_extendedprice",
-          "scalarType": "FLOAT",
-          "nullable": true
-        },
-        "l_discount": {
-          "name": "l_discount",
-          "scalarType": "FLOAT",
-          "nullable": true
-        },
-        "l_quantity": {
-          "name": "l_quantity",
-          "scalarType": "FLOAT",
-          "nullable": true
-        },
-        "l_partkey": {
-          "name": "l_partkey",
-          "scalarType": "INTEGER",
-          "nullable": true
-        },
-        "l_receiptdate": {
-          "name": "l_receiptdate",
-          "scalarType": "DATE",
-          "nullable": true
-        },
-        "l_shipmode": {
-          "name": "l_shipmode",
-          "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "l_returnflag": {
-          "name": "l_returnflag",
-          "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "l_commitdate": {
-          "name": "l_commitdate",
-          "scalarType": "DATE",
-          "nullable": true
-        },
-        "l_shipdate": {
-          "name": "l_shipdate",
-          "scalarType": "DATE",
-          "nullable": true
-        },
-        "l_linenumber": {
-          "name": "l_linenumber",
-          "scalarType": "INTEGER",
-          "nullable": true
-        },
-        "l_comment": {
-          "name": "l_comment",
-          "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "l_shipinstruct": {
-          "name": "l_shipinstruct",
-          "scalarType": "VARCHAR",
           "nullable": true
         }
       },
       "primaryKeys": [],
       "exportedKeys": []
     },
-    "part": {
-      "physicalCatalog": "samples",
-      "physicalSchema": "tpch",
+    "mediatype": {
+      "physicalCatalog": "hasura",
+      "physicalSchema": "testing",
       "catalog": "",
       "schema": "TEST",
-      "name": "part",
+      "name": "mediatype",
       "columns": {
-        "p_type": {
-          "name": "p_type",
+        "Name": {
+          "name": "Name",
           "scalarType": "VARCHAR",
           "nullable": true
         },
-        "p_mfgr": {
-          "name": "p_mfgr",
-          "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "p_partkey": {
-          "name": "p_partkey",
+        "MediaTypeId": {
+          "name": "MediaTypeId",
           "scalarType": "INTEGER",
-          "nullable": true
-        },
-        "p_comment": {
-          "name": "p_comment",
-          "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "p_retailprice": {
-          "name": "p_retailprice",
-          "scalarType": "FLOAT",
-          "nullable": true
-        },
-        "p_container": {
-          "name": "p_container",
-          "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "p_name": {
-          "name": "p_name",
-          "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "p_size": {
-          "name": "p_size",
-          "scalarType": "INTEGER",
-          "nullable": true
-        },
-        "p_brand": {
-          "name": "p_brand",
-          "scalarType": "VARCHAR",
           "nullable": true
         }
       },
       "primaryKeys": [],
       "exportedKeys": []
     },
-    "nation": {
-      "physicalCatalog": "samples",
-      "physicalSchema": "tpch",
+    "album": {
+      "physicalCatalog": "hasura",
+      "physicalSchema": "testing",
       "catalog": "",
       "schema": "TEST",
-      "name": "nation",
+      "name": "album",
       "columns": {
-        "n_name": {
-          "name": "n_name",
+        "Title": {
+          "name": "Title",
           "scalarType": "VARCHAR",
           "nullable": true
         },
-        "n_regionkey": {
-          "name": "n_regionkey",
+        "AlbumId": {
+          "name": "AlbumId",
           "scalarType": "INTEGER",
           "nullable": true
         },
-        "n_comment": {
-          "name": "n_comment",
+        "ArtistId": {
+          "name": "ArtistId",
+          "scalarType": "INTEGER",
+          "nullable": true
+        }
+      },
+      "primaryKeys": [],
+      "exportedKeys": []
+    },
+    "invoiceline": {
+      "physicalCatalog": "hasura",
+      "physicalSchema": "testing",
+      "catalog": "",
+      "schema": "TEST",
+      "name": "invoiceline",
+      "columns": {
+        "Quantity": {
+          "name": "Quantity",
+          "scalarType": "INTEGER",
+          "nullable": true
+        },
+        "TrackId": {
+          "name": "TrackId",
+          "scalarType": "INTEGER",
+          "nullable": true
+        },
+        "InvoiceId": {
+          "name": "InvoiceId",
+          "scalarType": "INTEGER",
+          "nullable": true
+        },
+        "UnitPrice": {
+          "name": "UnitPrice",
+          "scalarType": "DOUBLE",
+          "nullable": true
+        },
+        "InvoiceLineId": {
+          "name": "InvoiceLineId",
+          "scalarType": "INTEGER",
+          "nullable": true
+        }
+      },
+      "primaryKeys": [],
+      "exportedKeys": []
+    },
+    "invoice": {
+      "physicalCatalog": "hasura",
+      "physicalSchema": "testing",
+      "catalog": "",
+      "schema": "TEST",
+      "name": "invoice",
+      "columns": {
+        "Total": {
+          "name": "Total",
+          "scalarType": "DOUBLE",
+          "nullable": true
+        },
+        "BillingAddress": {
+          "name": "BillingAddress",
           "scalarType": "VARCHAR",
           "nullable": true
         },
-        "n_nationkey": {
-          "name": "n_nationkey",
+        "InvoiceDate": {
+          "name": "InvoiceDate",
+          "scalarType": "TIMESTAMP",
+          "nullable": true
+        },
+        "BillingCity": {
+          "name": "BillingCity",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "BillingPostalCode": {
+          "name": "BillingPostalCode",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "BillingCountry": {
+          "name": "BillingCountry",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "InvoiceId": {
+          "name": "InvoiceId",
           "scalarType": "INTEGER",
+          "nullable": true
+        },
+        "BillingState": {
+          "name": "BillingState",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "CustomerId": {
+          "name": "CustomerId",
+          "scalarType": "INTEGER",
+          "nullable": true
+        }
+      },
+      "primaryKeys": [],
+      "exportedKeys": []
+    },
+    "artist": {
+      "physicalCatalog": "hasura",
+      "physicalSchema": "testing",
+      "catalog": "",
+      "schema": "TEST",
+      "name": "artist",
+      "columns": {
+        "ArtistId": {
+          "name": "ArtistId",
+          "scalarType": "INTEGER",
+          "nullable": true
+        },
+        "Name": {
+          "name": "Name",
+          "scalarType": "VARCHAR",
           "nullable": true
         }
       },
@@ -226,49 +207,160 @@
       "exportedKeys": []
     },
     "customer": {
-      "physicalCatalog": "samples",
-      "physicalSchema": "tpch",
+      "physicalCatalog": "hasura",
+      "physicalSchema": "testing",
       "catalog": "",
       "schema": "TEST",
       "name": "customer",
       "columns": {
-        "c_acctbal": {
-          "name": "c_acctbal",
-          "scalarType": "FLOAT",
-          "nullable": true
-        },
-        "c_comment": {
-          "name": "c_comment",
+        "Phone": {
+          "name": "Phone",
           "scalarType": "VARCHAR",
           "nullable": true
         },
-        "c_phone": {
-          "name": "c_phone",
+        "Address": {
+          "name": "Address",
           "scalarType": "VARCHAR",
           "nullable": true
         },
-        "c_custkey": {
-          "name": "c_custkey",
+        "City": {
+          "name": "City",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "Company": {
+          "name": "Company",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "Country": {
+          "name": "Country",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "LastName": {
+          "name": "LastName",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "CustomerId": {
+          "name": "CustomerId",
           "scalarType": "INTEGER",
           "nullable": true
         },
-        "c_address": {
-          "name": "c_address",
+        "FirstName": {
+          "name": "FirstName",
           "scalarType": "VARCHAR",
           "nullable": true
         },
-        "c_name": {
-          "name": "c_name",
+        "PostalCode": {
+          "name": "PostalCode",
           "scalarType": "VARCHAR",
           "nullable": true
         },
-        "c_nationkey": {
-          "name": "c_nationkey",
+        "State": {
+          "name": "State",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "Fax": {
+          "name": "Fax",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "Email": {
+          "name": "Email",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "SupportRepId": {
+          "name": "SupportRepId",
+          "scalarType": "INTEGER",
+          "nullable": true
+        }
+      },
+      "primaryKeys": [],
+      "exportedKeys": []
+    },
+    "employee": {
+      "physicalCatalog": "hasura",
+      "physicalSchema": "testing",
+      "catalog": "",
+      "schema": "TEST",
+      "name": "employee",
+      "columns": {
+        "BirthDate": {
+          "name": "BirthDate",
+          "scalarType": "TIMESTAMP",
+          "nullable": true
+        },
+        "EmployeeId": {
+          "name": "EmployeeId",
           "scalarType": "INTEGER",
           "nullable": true
         },
-        "c_mktsegment": {
-          "name": "c_mktsegment",
+        "LastName": {
+          "name": "LastName",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "State": {
+          "name": "State",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "City": {
+          "name": "City",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "Fax": {
+          "name": "Fax",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "HireDate": {
+          "name": "HireDate",
+          "scalarType": "TIMESTAMP",
+          "nullable": true
+        },
+        "Email": {
+          "name": "Email",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "PostalCode": {
+          "name": "PostalCode",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "Title": {
+          "name": "Title",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "Address": {
+          "name": "Address",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "ReportsTo": {
+          "name": "ReportsTo",
+          "scalarType": "INTEGER",
+          "nullable": true
+        },
+        "Phone": {
+          "name": "Phone",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "FirstName": {
+          "name": "FirstName",
+          "scalarType": "VARCHAR",
+          "nullable": true
+        },
+        "Country": {
+          "name": "Country",
           "scalarType": "VARCHAR",
           "nullable": true
         }
@@ -276,138 +368,77 @@
       "primaryKeys": [],
       "exportedKeys": []
     },
-    "supplier": {
-      "physicalCatalog": "samples",
-      "physicalSchema": "tpch",
+    "genre": {
+      "physicalCatalog": "hasura",
+      "physicalSchema": "testing",
       "catalog": "",
       "schema": "TEST",
-      "name": "supplier",
+      "name": "genre",
       "columns": {
-        "s_nationkey": {
-          "name": "s_nationkey",
+        "GenreId": {
+          "name": "GenreId",
           "scalarType": "INTEGER",
           "nullable": true
         },
-        "s_name": {
-          "name": "s_name",
+        "Name": {
+          "name": "Name",
           "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "s_phone": {
-          "name": "s_phone",
-          "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "s_suppkey": {
-          "name": "s_suppkey",
-          "scalarType": "INTEGER",
-          "nullable": true
-        },
-        "s_address": {
-          "name": "s_address",
-          "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "s_comment": {
-          "name": "s_comment",
-          "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "s_acctbal": {
-          "name": "s_acctbal",
-          "scalarType": "FLOAT",
           "nullable": true
         }
       },
       "primaryKeys": [],
       "exportedKeys": []
     },
-    "orders": {
-      "physicalCatalog": "samples",
-      "physicalSchema": "tpch",
+    "track": {
+      "physicalCatalog": "hasura",
+      "physicalSchema": "testing",
       "catalog": "",
       "schema": "TEST",
-      "name": "orders",
+      "name": "track",
       "columns": {
-        "o_orderdate": {
-          "name": "o_orderdate",
-          "scalarType": "DATE",
-          "nullable": true
-        },
-        "o_shippriority": {
-          "name": "o_shippriority",
-          "scalarType": "INTEGER",
-          "nullable": true
-        },
-        "o_orderstatus": {
-          "name": "o_orderstatus",
+        "Name": {
+          "name": "Name",
           "scalarType": "VARCHAR",
           "nullable": true
         },
-        "o_custkey": {
-          "name": "o_custkey",
+        "GenreId": {
+          "name": "GenreId",
           "scalarType": "INTEGER",
           "nullable": true
         },
-        "o_clerk": {
-          "name": "o_clerk",
+        "TrackId": {
+          "name": "TrackId",
+          "scalarType": "INTEGER",
+          "nullable": true
+        },
+        "Milliseconds": {
+          "name": "Milliseconds",
+          "scalarType": "INTEGER",
+          "nullable": true
+        },
+        "MediaTypeId": {
+          "name": "MediaTypeId",
+          "scalarType": "INTEGER",
+          "nullable": true
+        },
+        "AlbumId": {
+          "name": "AlbumId",
+          "scalarType": "INTEGER",
+          "nullable": true
+        },
+        "Bytes": {
+          "name": "Bytes",
+          "scalarType": "INTEGER",
+          "nullable": true
+        },
+        "UnitPrice": {
+          "name": "UnitPrice",
+          "scalarType": "DOUBLE",
+          "nullable": true
+        },
+        "Composer": {
+          "name": "Composer",
           "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "o_orderkey": {
-          "name": "o_orderkey",
-          "scalarType": "INTEGER",
-          "nullable": true
-        },
-        "o_comment": {
-          "name": "o_comment",
-          "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "o_orderpriority": {
-          "name": "o_orderpriority",
-          "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "o_totalprice": {
-          "name": "o_totalprice",
-          "scalarType": "FLOAT",
-          "nullable": true
-        }
-      },
-      "primaryKeys": [],
-      "exportedKeys": []
-    },
-    "partsupp": {
-      "physicalCatalog": "samples",
-      "physicalSchema": "tpch",
-      "catalog": "",
-      "schema": "TEST",
-      "name": "partsupp",
-      "columns": {
-        "ps_availqty": {
-          "name": "ps_availqty",
-          "scalarType": "INTEGER",
-          "nullable": true
-        },
-        "ps_partkey": {
-          "name": "ps_partkey",
-          "scalarType": "INTEGER",
-          "nullable": true
-        },
-        "ps_comment": {
-          "name": "ps_comment",
-          "scalarType": "VARCHAR",
-          "nullable": true
-        },
-        "ps_suppkey": {
-          "name": "ps_suppkey",
-          "scalarType": "INTEGER",
-          "nullable": true
-        },
-        "ps_supplycost": {
-          "name": "ps_supplycost",
-          "scalarType": "FLOAT",
           "nullable": true
         }
       },

--- a/adapters/databricks/model.json
+++ b/adapters/databricks/model.json
@@ -7,8 +7,8 @@
       "type": "jdbc",
       "jdbcDriver": "com.databricks.client.jdbc.Driver",
       "jdbcUrl": "${DATABRICKS_JDBC_URL}",
-      "jdbcSchema": "workspace",
-      "jdbcCatalog": "chinook"
+      "jdbcSchema": "${DATABRICKS_SCHEMA}",
+      "jdbcCatalog": "${DATABRICKS_CATALOG}"
     }
   ]
 }

--- a/adapters/databricks/schema.json
+++ b/adapters/databricks/schema.json
@@ -1,124 +1,72 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ParsedConfiguration",
+  "description": "Initial configuration, just enough to connect to a database and elaborate a full 'Configuration'.",
   "type": "object",
   "required": [
     "version"
   ],
   "properties": {
     "version": {
-      "$ref": "#/definitions/Version"
+      "description": "Hasura NDC version",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Version"
+        }
+      ]
     },
     "$schema": {
-      "type": "string"
+      "description": "JSON Schema file that defines a valid configuration",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "model": {
-      "type": "object",
-      "properties": {
-        "version": {
-          "type": "string"
+      "description": "The Calcite Model - somewhat dependent on type of calcite adapter being used. Better documentation can be found [here](https://calcite.apache.org/docs/model.html).",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Model"
         },
-        "defaultSchema": {
-          "type": "string"
-        },
-        "schemas": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "jdbcUser": {
-                "type": "string"
-              },
-              "jdbcPassword": {
-                "type": "string"
-              },
-              "jdbcUrl": {
-                "type": "string"
-              },
-              "sqlDialectFactory": {
-                "type": "string"
-              },
-              "jdbcCatalog": {
-                "type": "string"
-              },
-              "jdbcSchema": {},
-              "factory": {
-                "type": "string"
-              },
-              "operand": {
-                "type": "object",
-                "properties": {
-                  "directory": {
-                    "type": "string"
-                  },
-                  "host": {
-                    "type": "string"
-                  },
-                  "port": {
-                    "type": "number"
-                  },
-                  "database": {
-                    "type": "string"
-                  },
-                  "password": {
-                    "type": "string"
-                  }
-                }
-              },
-              "tables": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "factory": {
-                      "type": "string"
-                    },
-                    "operand": {
-                      "type": "object",
-                      "properties": {
-                        "dataFormat": {
-                          "type": "string"
-                        },
-                        "fields": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "name": {
-                                "type": "string"
-                              },
-                              "type": {
-                                "type": "string"
-                              },
-                              "mapping": {}
-                            },
-                            "required": [
-                              "name",
-                              "type",
-                              "mapping"
-                            ]
-                          }
-                        },
-                        "keyDelimiter": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+        {
+          "type": "null"
         }
+      ]
+    },
+    "model_file_path": {
+      "description": "Used internally",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "fixes": {
+      "description": "Certain fixes that will solve for missing field values, for non-existing fields. It's expensive and probably not necessary, but required to pass the NDC tests. You can set the value to false in order to improve performance.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "supportJsonObject": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "jars": {
+      "description": "Many common JDBC jars are included by default. Some are not you can create a directory with additional required JARS and point to that directory here.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "metadata": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "$ref": "#/definitions/TableMetadata"
       }
     }
   },
@@ -128,6 +76,780 @@
       "enum": [
         "5"
       ]
+    },
+    "Model": {
+      "description": "Represents a model. This is explained in greater detail in the Apache Calcite docs.",
+      "type": "object",
+      "required": [
+        "version"
+      ],
+      "properties": {
+        "version": {
+          "description": "Calcite version",
+          "type": "string"
+        },
+        "defaultSchema": {
+          "description": "You can define multiple schemas - this will be the default one",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schemas": {
+          "description": "An array of Schemas. Schemas represent a connection/configuration of a data source.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Schema"
+          }
+        },
+        "functions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Function"
+          }
+        },
+        "types": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Type"
+          }
+        }
+      }
+    },
+    "Schema": {
+      "description": "The type of the schema.",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "cache": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "path": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": true
+        },
+        "sqlDialectFactory": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "jdbcUser": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "jdbcPassword": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "jdbcUrl": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "jdbcCatalog": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "jdbcSchema": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "factory": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operand": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Operand"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "types": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Type"
+          }
+        },
+        "materializations": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Materialization"
+          }
+        },
+        "lattices": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Lattice"
+          }
+        },
+        "tables": {
+          "description": "If the schema cannot infer table structures (think NoSQL) define them here.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Table"
+          }
+        }
+      }
+    },
+    "Operand": {
+      "description": "Represents the operand used in the schema.",
+      "type": "object",
+      "properties": {
+        "directory": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "host": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "port": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "database": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "password": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "username": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "keyspace": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "dataFormat": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ssl": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pathToCert": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pathToPrivateKey": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "keyPassword": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pathToRootCert": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Type": {
+      "type": "object",
+      "required": [
+        "name",
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Type"
+          }
+        }
+      }
+    },
+    "Materialization": {
+      "type": "object",
+      "properties": {
+        "view": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "table": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sql": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Lattice": {
+      "description": "Represents a lattice in the schema. A lattice (in Calcite) refers to aggregates.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sql": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "auto": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "algorithm": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "algorithmMaxMillis": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "rowCountEstimate": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64"
+        },
+        "defaultMeasures": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Measure"
+          }
+        },
+        "tiles": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Tile"
+          }
+        }
+      }
+    },
+    "Measure": {
+      "type": "object",
+      "properties": {
+        "agg": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "args": true
+      }
+    },
+    "Tile": {
+      "type": "object",
+      "properties": {
+        "dimensions": true,
+        "measures": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Measure"
+          }
+        }
+      }
+    },
+    "Table": {
+      "description": "Represents a table.\n\n## Fields\n\n- `name` - The name of the table. It is an optional field. - `factory` - The factory of the table. It is an optional field. - `operand` - The operand of the table. It is an optional field.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "factory": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "index": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "tableName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operand": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Operand"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "columns": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Column"
+          }
+        },
+        "fieldDefs": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/FieldDef"
+          }
+        },
+        "sql": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "modifiable": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "stream": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "history": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "Column": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "FieldDef": {
+      "type": "object",
+      "properties": {
+        "th": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "selector": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "skip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pattern": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "matchGroup": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "selectedElement": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Function": {
+      "description": "Represents a function.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "className": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "methodName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TableMetadata": {
+      "description": "Represents metadata for a database table.\n\n# Fields\n\n- `catalog` - The catalog of the table. - `schema` - The schema of the table. - `name` - The name of the table. - `description` - The description of the table. - `columns` - A `HashMap` containing the columns of the table. - `primary_keys` - An optional `Vec` of primary key column names. - `exported_keys` - An optional `Vec` of exported keys to other tables.",
+      "type": "object",
+      "required": [
+        "columns",
+        "name"
+      ],
+      "properties": {
+        "physicalCatalog": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "physicalSchema": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "catalog": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "columns": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ColumnMetadata"
+          }
+        },
+        "primaryKeys": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "exportedKeys": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ExportedKey"
+          }
+        }
+      }
+    },
+    "ColumnMetadata": {
+      "description": "Represents the metadata of a column in a database table.",
+      "type": "object",
+      "required": [
+        "name",
+        "nullable",
+        "scalarType"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "scalarType": {
+          "type": "string"
+        },
+        "nullable": {
+          "type": "boolean"
+        }
+      }
+    },
+    "ExportedKey": {
+      "description": "Represents an exported key between two tables in a database.",
+      "type": "object",
+      "required": [
+        "fkColumnName",
+        "fkTableName",
+        "pkColumnName",
+        "pkTableName"
+      ],
+      "properties": {
+        "pkTableCatalog": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pkTableSchema": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pkTableName": {
+          "type": "string"
+        },
+        "pkColumnName": {
+          "type": "string"
+        },
+        "pkName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "fkTableCatalog": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "fkTableSchema": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "fkTableName": {
+          "type": "string"
+        },
+        "fkColumnName": {
+          "type": "string"
+        },
+        "fkName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
     }
   }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -124,7 +124,8 @@ async fn initialize(
             DOCKER_IMAGE_NAME,
             context.release_version.unwrap_or("latest")
         );
-        let update_command = format!("docker run --entry-point ndc-calcite-cli -e HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH -v ${{HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}}:{} -v ${{HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}}:{}:ro {} update", DOCKER_CONNECTOR_DIR, DOCKER_CONNECTOR_RW, docker_image);
+        let update_command =
+            format!("docker run --entry-point ndc-calcite-cli -e HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH -v ${{HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}}:{} {} update", DOCKER_CONNECTOR_DIR, docker_image);
         let metadata = metadata::ConnectorMetadataDefinition {
             packaging_definition: metadata::PackagingDefinition::PrebuiltDockerImage(
                 metadata::PrebuiltDockerImagePackaging { docker_image },

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -152,7 +152,7 @@ async fn initialize(
         };
 
         fs::write(metadata_file, serde_yaml::to_string(&metadata)?).await?;
-    }
+    };
 
     Ok(())
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -5,7 +5,6 @@
 
 use regex::Regex;
 use std::path::PathBuf;
-
 use anyhow::Ok;
 use clap::Subcommand;
 use include_dir::Dir;
@@ -175,7 +174,7 @@ async fn update(
             metadata::ConnectorMetadataDefinition,
         >(&metadata_yaml)?))
     } else {
-        Err(anyhow::Error::msg("Metadata file does not exist at {config_path}.hasura-connector/connector-metadata.yaml"))
+        Err(anyhow::Error::msg(format!("Metadata file does not exist at {config_path:?}/.hasura-connector/connector-metadata.yaml")))
     }?;
     let supported_env_vars = metadata
         .as_ref()

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,8 +2,6 @@
 //!
 //! This is intended to be automatically downloaded and invoked via the Hasura CLI, as a plugin.
 //! It is unlikely that end-users will use it directly.
-
-use std::env;
 use std::path::PathBuf;
 use std::process::ExitCode;
 use clap::Parser;
@@ -24,8 +22,8 @@ const RELEASE_VERSION: Option<&str> = option_env!("RELEASE_VERSION");
 )]
 pub struct Args {
     /// The path to the configuration. Defaults to the current directory.
-    #[arg(long = "context", env = "HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH")]
-    pub context_path: Option<PathBuf>,
+    #[arg(long = "context", env = "CONNECTOR_CONTEXT_PATH")]
+    pub context_path: PathBuf,
     /// The command to invoke.
     #[command(subcommand)]
     pub subcommand: Command,
@@ -53,10 +51,7 @@ pub async fn main() -> ExitCode {
 async fn try_main(calcite_ref_singleton: CalciteRefSingleton) -> anyhow::Result<()> {
     let args = Args::parse();
     // Default the context path to the current directory.
-    let context_path = match args.context_path {
-        Some(path) => path,
-        None => env::current_dir()?,
-    };
+    let context_path = args.context_path;
     let context = Context {
         context_path,
         environment: configuration::environment::ProcessEnvironment,


### PR DESCRIPTION
# Environment Variable Standardization for Configuration Path

## Changes
- Introduces new required environment variable `CONNECTOR_CONTEXT_PATH` to specify the configuration directory path
- Standardizes configuration path handling between local and containerized environments

## Bug Fix
Fixes CLI update functionality by correctly resolving `.hasura-connector/connector-metadata.yaml` path in Docker environment. Previously, the CLI was unable to locate this file when run in a container because:
- Docker mounts configuration at `/etc/connector`
- CLI had no way to determine this mounted path
- `CONNECTOR_CONTEXT_PATH` now provides this information consistently

This change eliminates the need for separate path handling logic between local and Docker environments.